### PR TITLE
Allow sequences in parameter specifications with urlencode

### DIFF
--- a/brightcove/core.py
+++ b/brightcove/core.py
@@ -43,7 +43,7 @@ class Connection(object):
         if params is None:
             params = {}
         params.update({'token': self.token})
-        data = urllib.urlencode(params)
+        data = urllib.urlencode(params, True)
         url = '%s?%s' % (url, data)
         return self._request(url)
 


### PR DESCRIPTION
This fixes problems when specifying multiple search criteria. 
Currently, trying to query multiple search criteria fails due to the urlencode not supporting sequences, e.g. this example fails:

```
b = Brightcove('lWCaZyhokufjqe7H4TLpXwHSTnNXtqHxyMvoNOsmYA_GRaZ4zcwysw..')
b.search_videos(all=['tv_show:Offspring','video_type_long_form:Full Episode'])
```

This one-line change fixes this problem by telling urlencode to separate sequences correctly.
